### PR TITLE
fix(vyos): clone vyos-build rolling branch instead of current

### DIFF
--- a/scripts/vyos/build-vyos.sh
+++ b/scripts/vyos/build-vyos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script will build a VyOS qcow2 image inside a docker container. The
-# VyOS version is set to 'current' and matches v1.5. Optionally, the full
+# VyOS version is set to 'rolling' and matches v1.5. Optionally, the full
 # path to a miniccc binary can be passed as another command line argument
 # and it will be injected into the final image, including a startup script
 # that runs on bootup. The final qcow2 image will be at: ./vyos.qc2
@@ -225,7 +225,7 @@ function build_vyos() {
 
     # fetch build files
     cd $CWD
-    git clone -b current --single-branch https://github.com/vyos/vyos-build
+    git clone -b rolling --single-branch https://github.com/vyos/vyos-build
     cd vyos-build
     git pull
 
@@ -239,14 +239,16 @@ image_format = "qcow2"
 packages = [$PACKAGES"qemu-guest-agent", "vim"]
 EOF
 
-    # build vyos
-    docker pull ghcr.io/sandialabs/sceptre-phenix-images/vyos-build:current
+    ## build vyos
+    # this docker image is a clone of docker.io/vyos/vyos-build:rolling,
+    # pushed here to avoid rate limits
+    docker pull ghcr.io/sandialabs/sceptre-phenix-images/vyos-build:rolling
     docker run --rm \
         -v /dev:/dev \
         -v $CWD/vyos-build:/root \
         -w /root --privileged \
         -e GOSU_UID="$(id -u)" -e GOSU_GID="$(id -g)" \
-        ghcr.io/sandialabs/sceptre-phenix-images/vyos-build:current \
+        ghcr.io/sandialabs/sceptre-phenix-images/vyos-build:rolling \
         bash -c "sudo make -j$(nproc) qemu"
 
     if [ -f "$MINICCC_PATH" ]; then


### PR DESCRIPTION
# fix(vyos): clone vyos-build rolling branch instead of current

## Description
Upstream `vyos/vyos-build` renamed its default branch from `current` to `rolling`, breaking the VyOS image build. Updates `scripts/vyos/build-vyos.sh` to clone the `rolling` branch and to pull/run the `:rolling` tag of the `vyos-build` container image (mirrored to GHCR to avoid Docker Hub rate limits).

Replaces #5, which was opened from a branch name (`claude/vyos-image-build-rolling-963o5m`) that doesn't conform to the repo's `no-commit-to-branch` prek hook (kebab-case only, no `/`).

## Related Issue
N/A

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-images/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Same change as #5, cherry-picked onto a compliant branch name. The `build-images (vyos)` matrix job was passing on #5 prior to closing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJjhxafZ8biAVQdu4AqgED)_